### PR TITLE
Feature 20170122

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.igapyon.diary.v3</groupId>
 	<artifactId>IgapyonV3</artifactId>
-	<version>1.2.5</version>
+	<version>1.2.6</version>
 	<packaging>jar</packaging>
 
 	<name>IgapyonV3</name>

--- a/src/main/java/jp/igapyon/diary/v3/md2html/IgapyonDirProcessor.java
+++ b/src/main/java/jp/igapyon/diary/v3/md2html/IgapyonDirProcessor.java
@@ -69,7 +69,15 @@ public abstract class IgapyonDirProcessor {
 		if (origName.contains(".") == false) {
 			return origName + newExt;
 		}
-		final String withoutExt = origName.substring(0, origName.indexOf("."));
+		if (origName.endsWith(".html.md")) {
+			// for igapyonv3
+			return origName.substring(0, origName.lastIndexOf("."));
+		}
+		if (origName.endsWith(".html.src.md")) {
+			// for igapyonv3
+			return origName.substring(0, origName.length() - ".html.src.md".length()) + ".src.html";
+		}
+		final String withoutExt = origName.substring(0, origName.lastIndexOf("."));
 		return withoutExt + newExt;
 	}
 

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
@@ -83,10 +83,10 @@ public class IgapyonV3FreeMarkerUtil {
 
 		final Configuration config = getConfiguration(settings, true);
 
-		// set settings obj
+		// Pre-define value
 		templateData.put("settings", settings);
 
-		final IgapyonV3Current current = new IgapyonV3Current();
+		IgapyonV3Current current = null;
 
 		final Template templateBase = config.getTemplate(relativePath);
 
@@ -99,20 +99,7 @@ public class IgapyonV3FreeMarkerUtil {
 
 			// ここで得られた 展開後の md ファイルを入力として、current オブジェクトへのプリセットを実施します。
 
-			{
-				final BufferedReader reader = new BufferedReader(new StringReader(writer.toString()));
-				for (;;) {
-					String line = reader.readLine();
-					if (line == null) {
-						break;
-					}
-					// 最初の ## からテキストを取得。これは igapyonv3 の最大の制約です。
-					if (line.startsWith("## ")) {
-						current.setTitle(line.substring(3));
-						break;
-					}
-				}
-			}
+			current = buildCurrentObjectByPreParse(writer.toString());
 		} catch (TemplateException e) {
 			throw new IOException(e);
 		}
@@ -127,6 +114,27 @@ public class IgapyonV3FreeMarkerUtil {
 		} catch (TemplateException e) {
 			throw new IOException(e);
 		}
+	}
+
+	public static IgapyonV3Current buildCurrentObjectByPreParse(final String sourceString) throws IOException {
+		final IgapyonV3Current current = new IgapyonV3Current();
+
+		final BufferedReader reader = new BufferedReader(new StringReader(sourceString));
+		for (;;) {
+			final String line = reader.readLine();
+			if (line == null) {
+				break;
+			}
+			// 最初の ## からテキストを取得。これは igapyonv3 の最大の制約です。
+			if (line.startsWith("## ")) {
+				current.setTitle(line.substring(3));
+				break;
+			}
+		}
+
+		// TODO これ以外に、キーワードのリスト抽出とか、いろいろやりたいのだが。。。
+
+		return current;
 	}
 
 	/**

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
@@ -33,8 +33,10 @@
 
 package jp.igapyon.diary.v3.mdconv.freemarker;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -84,6 +86,8 @@ public class IgapyonV3FreeMarkerUtil {
 		// set settings obj
 		templateData.put("settings", settings);
 
+		final IgapyonV3Current current = new IgapyonV3Current();
+
 		final Template templateBase = config.getTemplate(relativePath);
 
 		try {
@@ -92,22 +96,29 @@ public class IgapyonV3FreeMarkerUtil {
 
 			final StringWriter writer = new StringWriter();
 			templateBase.process(templateData, writer);
-			// System.out.println("wrk[" + writer.toString() + "]");
 
 			// ここで得られた 展開後の md ファイルを入力として、current オブジェクトへのプリセットを実施します。
-			// TODO 該当機能は未実装です。
-			// FIXME 該当機能は未実装です。
+
+			{
+				final BufferedReader reader = new BufferedReader(new StringReader(writer.toString()));
+				for (;;) {
+					String line = reader.readLine();
+					if (line == null) {
+						break;
+					}
+					// 最初の ## からテキストを取得。これは igapyonv3 の最大の制約です。
+					if (line.startsWith("## ")) {
+						current.setTitle(line.substring(3));
+						break;
+					}
+				}
+			}
 		} catch (TemplateException e) {
 			throw new IOException(e);
 		}
 
-		final IgapyonV3Current current = new IgapyonV3Current();
+		// 空読みで得られた知見を current に反映したい。
 		templateData.put("current", current);
-
-		{
-			// 空読みで得られた知見を current に反映したい。
-			// FIXME not implemented. さしあたり title と url がほしい。
-		}
 
 		try {
 			final StringWriter writer = new StringWriter();

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
@@ -52,6 +52,7 @@ import jp.igapyon.diary.v3.mdconv.freemarker.directive.LinkShareDirectiveModel;
 import jp.igapyon.diary.v3.mdconv.freemarker.directive.LocalRssDirectiveModel;
 import jp.igapyon.diary.v3.mdconv.freemarker.directive.LocalYearlistDirectiveModel;
 import jp.igapyon.diary.v3.mdconv.freemarker.directive.RSSFeedDirectiveModel;
+import jp.igapyon.diary.v3.util.IgapyonV3Current;
 import jp.igapyon.diary.v3.util.IgapyonV3Settings;
 import jp.igapyon.diary.v3.util.SimpleDirUtil;
 
@@ -84,6 +85,30 @@ public class IgapyonV3FreeMarkerUtil {
 		templateData.put("settings", settings);
 
 		final Template templateBase = config.getTemplate(relativePath);
+
+		try {
+			// 一旦、事前準備運動として空読み込みを実施します。
+			templateData.put("current", new IgapyonV3Current());
+
+			final StringWriter writer = new StringWriter();
+			templateBase.process(templateData, writer);
+			// System.out.println("wrk[" + writer.toString() + "]");
+
+			// ここで得られた 展開後の md ファイルを入力として、current オブジェクトへのプリセットを実施します。
+			// TODO 該当機能は未実装です。
+			// FIXME 該当機能は未実装です。
+		} catch (TemplateException e) {
+			throw new IOException(e);
+		}
+
+		final IgapyonV3Current current = new IgapyonV3Current();
+		templateData.put("current", current);
+
+		{
+			// 空読みで得られた知見を current に反映したい。
+			// FIXME not implemented. さしあたり title と url がほしい。
+		}
+
 		try {
 			final StringWriter writer = new StringWriter();
 			templateBase.process(templateData, writer);

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/IgapyonV3FreeMarkerUtil.java
@@ -43,6 +43,7 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import jp.igapyon.diary.v3.mdconv.freemarker.directive.IncludeDirectiveModel;
+import jp.igapyon.diary.v3.mdconv.freemarker.directive.LastModifiedDirectiveModel;
 import jp.igapyon.diary.v3.mdconv.freemarker.directive.LinkAmazonDirectiveModel;
 import jp.igapyon.diary.v3.mdconv.freemarker.directive.LinkDiaryDirectiveModel;
 import jp.igapyon.diary.v3.mdconv.freemarker.directive.LinkMapDirectiveModel;
@@ -139,6 +140,7 @@ public class IgapyonV3FreeMarkerUtil {
 		config.setSharedVariable("linkmap", new LinkMapDirectiveModel(settings));
 		config.setSharedVariable("linkamazon", new LinkAmazonDirectiveModel(settings));
 		config.setSharedVariable("localyearlist", new LocalYearlistDirectiveModel(settings));
+		config.setSharedVariable("lastmodified", new LastModifiedDirectiveModel(settings));
 
 		return config;
 	}

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/IncludeDirectiveModel.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/IncludeDirectiveModel.java
@@ -44,7 +44,6 @@ import freemarker.template.Template;
 import freemarker.template.TemplateDirectiveBody;
 import freemarker.template.TemplateDirectiveModel;
 import freemarker.template.TemplateException;
-import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import jp.igapyon.diary.v3.mdconv.freemarker.IgapyonV3FreeMarkerUtil;
@@ -85,12 +84,7 @@ public class IncludeDirectiveModel implements TemplateDirectiveModel {
 
 			final Configuration config = IgapyonV3FreeMarkerUtil.getConfiguration(settings, false);
 
-			{
-				TemplateHashModel model = env.getDataModel();
-				System.out.println("TRACE: XXX: " + model.get("settings"));
-			}
-
-			// include 中は、もとのデータモデル空間と同一とみなします。
+			// include 中は、呼び出し元のデータモデル空間と同一とみなします。
 
 			final Template templateBase = config.getTemplate(relativePath);
 			try {

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/IncludeDirectiveModel.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/IncludeDirectiveModel.java
@@ -36,8 +36,6 @@ package jp.igapyon.diary.v3.mdconv.freemarker.directive;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.util.HashMap;
 import java.util.Map;
 
 import freemarker.core.Environment;
@@ -46,10 +44,10 @@ import freemarker.template.Template;
 import freemarker.template.TemplateDirectiveBody;
 import freemarker.template.TemplateDirectiveModel;
 import freemarker.template.TemplateException;
+import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import jp.igapyon.diary.v3.mdconv.freemarker.IgapyonV3FreeMarkerUtil;
-import jp.igapyon.diary.v3.util.IgapyonV3Current;
 import jp.igapyon.diary.v3.util.IgapyonV3Settings;
 import jp.igapyon.diary.v3.util.SimpleDirUtil;
 
@@ -80,8 +78,6 @@ public class IncludeDirectiveModel implements TemplateDirectiveModel {
 		final File targetFile = new File(sourceDir, fileString);
 
 		{
-			final Map<String, Object> templateData = new HashMap<String, Object>();
-
 			// do canonical
 			final File rootdir = settings.getRootdir().getCanonicalFile();
 
@@ -89,27 +85,16 @@ public class IncludeDirectiveModel implements TemplateDirectiveModel {
 
 			final Configuration config = IgapyonV3FreeMarkerUtil.getConfiguration(settings, false);
 
-			// Pre-define value
-			templateData.put("settings", settings);
-
-			IgapyonV3Current current = null;
-			try {
-				// 一旦、事前準備運動として空読み込みを実施します。
-				templateData.put("current", new IgapyonV3Current());
-
-				final StringWriter buf = new StringWriter();
-				final Template templateBase = config.getTemplate(relativePath);
-				templateBase.process(templateData, buf);
-
-				// ここで得られた 展開後の md ファイルを入力として、current オブジェクトへのプリセットを実施します。
-				current = IgapyonV3FreeMarkerUtil.buildCurrentObjectByPreParse(buf.toString());
-			} catch (TemplateException e) {
-				throw new IOException(e);
+			{
+				TemplateHashModel model = env.getDataModel();
+				System.out.println("TRACE: XXX: " + model.get("settings"));
 			}
+
+			// include 中は、もとのデータモデル空間と同一とみなします。
 
 			final Template templateBase = config.getTemplate(relativePath);
 			try {
-				templateBase.process(templateData, writer);
+				templateBase.process(env.getDataModel(), writer);
 			} catch (TemplateException e) {
 				throw new IOException(e);
 			}

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/IncludeDirectiveModel.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/IncludeDirectiveModel.java
@@ -36,6 +36,7 @@ package jp.igapyon.diary.v3.mdconv.freemarker.directive;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,6 +49,7 @@ import freemarker.template.TemplateException;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import jp.igapyon.diary.v3.mdconv.freemarker.IgapyonV3FreeMarkerUtil;
+import jp.igapyon.diary.v3.util.IgapyonV3Current;
 import jp.igapyon.diary.v3.util.IgapyonV3Settings;
 import jp.igapyon.diary.v3.util.SimpleDirUtil;
 
@@ -86,6 +88,24 @@ public class IncludeDirectiveModel implements TemplateDirectiveModel {
 			final String relativePath = SimpleDirUtil.getRelativePath(rootdir, targetFile);
 
 			final Configuration config = IgapyonV3FreeMarkerUtil.getConfiguration(settings, false);
+
+			// Pre-define value
+			templateData.put("settings", settings);
+
+			IgapyonV3Current current = null;
+			try {
+				// 一旦、事前準備運動として空読み込みを実施します。
+				templateData.put("current", new IgapyonV3Current());
+
+				final StringWriter buf = new StringWriter();
+				final Template templateBase = config.getTemplate(relativePath);
+				templateBase.process(templateData, buf);
+
+				// ここで得られた 展開後の md ファイルを入力として、current オブジェクトへのプリセットを実施します。
+				current = IgapyonV3FreeMarkerUtil.buildCurrentObjectByPreParse(buf.toString());
+			} catch (TemplateException e) {
+				throw new IOException(e);
+			}
 
 			final Template templateBase = config.getTemplate(relativePath);
 			try {

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/LastModifiedDirectiveModel.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/LastModifiedDirectiveModel.java
@@ -1,0 +1,75 @@
+/*
+ *  Igapyon Diary system v3 (IgapyonV3).
+ *  Copyright (C) 2015-2017  Toshiki Iga
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ *  Copyright 2015-2017 Toshiki Iga
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package jp.igapyon.diary.v3.mdconv.freemarker.directive;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Map;
+
+import freemarker.core.Environment;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import jp.igapyon.diary.v3.util.IgapyonV3Settings;
+
+/**
+ * 最終更新日を蓄えるディレクティブモデル
+ * 
+ * @author Toshiki Iga
+ */
+public class LastModifiedDirectiveModel implements TemplateDirectiveModel {
+	private IgapyonV3Settings settings = null;
+
+	public LastModifiedDirectiveModel(final IgapyonV3Settings settings) {
+		this.settings = settings;
+	}
+
+	public void execute(final Environment env, @SuppressWarnings("rawtypes") final Map params,
+			final TemplateModel[] loopVars, final TemplateDirectiveBody body) throws TemplateException, IOException {
+		final BufferedWriter writer = new BufferedWriter(env.getOut());
+
+		if (params.get("date") == null) {
+			throw new TemplateModelException("dp param is required.");
+		}
+
+		// SimpleScalar#toString()
+		final String dateString = params.get("date").toString();
+
+		writer.write("Last modified: $Date: " + dateString + " $");
+
+		writer.flush();
+	}
+}

--- a/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/LinkSearchDirectiveModel.java
+++ b/src/main/java/jp/igapyon/diary/v3/mdconv/freemarker/directive/LinkSearchDirectiveModel.java
@@ -71,15 +71,15 @@ public class LinkSearchDirectiveModel implements TemplateDirectiveModel {
 			final TemplateModel[] loopVars, final TemplateDirectiveBody body) throws TemplateException, IOException {
 		final BufferedWriter writer = new BufferedWriter(env.getOut());
 
-		if (params.get("title") == null) {
-			throw new TemplateModelException("title param is required.");
-		}
 		if (params.get("word") == null) {
 			throw new TemplateModelException("word param is required.");
 		}
 
 		// SimpleScalar#toString()
-		final String titleString = params.get("title").toString();
+		String titleString = null;
+		if (params.get("title") != null) {
+			titleString = params.get("title").toString();
+		}
 		final String wordString = params.get("word").toString();
 
 		String siteString = null;
@@ -90,6 +90,11 @@ public class LinkSearchDirectiveModel implements TemplateDirectiveModel {
 		String engineString = "google";
 		if (params.get("engine") != null) {
 			engineString = params.get("engine").toString();
+		}
+
+		if (titleString == null) {
+			// タイトル文字指定がない場合は、規定の文言を生成します。
+			titleString = "Search '" + wordString + "' in " + engineString;
 		}
 
 		final URLCodec codec = new URLCodec();

--- a/src/main/java/jp/igapyon/diary/v3/util/IgapyonV3Current.java
+++ b/src/main/java/jp/igapyon/diary/v3/util/IgapyonV3Current.java
@@ -1,0 +1,46 @@
+/*
+ *  Igapyon Diary system v3 (IgapyonV3).
+ *  Copyright (C) 2015-2017  Toshiki Iga
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ *  Copyright 2015-2017 Toshiki Iga
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package jp.igapyon.diary.v3.util;
+
+public class IgapyonV3Current {
+	private String title = "N/A";
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+}

--- a/src/main/java/jp/igapyon/diary/v3/util/MdTextUtil.java
+++ b/src/main/java/jp/igapyon/diary/v3/util/MdTextUtil.java
@@ -121,7 +121,7 @@ public class MdTextUtil {
 			}
 		}
 
-		System.err.println("Non processed [[" + foundKeyword + "]] doubleword.");
+		System.err.println("Keyword [[" + foundKeyword + "]] was skipped.");
 
 		return source;
 	}

--- a/test/data/directive/localyearlist/test_localyearlist.html.md
+++ b/test/data/directive/localyearlist/test_localyearlist.html.md
@@ -3,3 +3,6 @@
 [2017](https://igapyon.github.io/diary/2017/index.html)
 / [ALL](https://igapyon.github.io/diary/idxall.html)
 
+
+test: Test
+

--- a/test/data/directive/localyearlist/test_localyearlist.html.src.md
+++ b/test/data/directive/localyearlist/test_localyearlist.html.src.md
@@ -1,3 +1,6 @@
 ## Test
 
 <@localyearlist />
+
+test: ${current.title}
+

--- a/test/data/hatena/ig161226.html.md
+++ b/test/data/hatena/ig161226.html.md
@@ -40,6 +40,8 @@ test data.
 
 
 
+* Last modified: $Date: 2017-01-22 $
+
 ## 登場キーワード
 
 * maven

--- a/test/data/hatena/ig161226.html.md
+++ b/test/data/hatena/ig161226.html.md
@@ -28,7 +28,7 @@ test data.
 
 
 * [JDBC本](https://www.amazon.co.jp/exec/obidos/ASIN/4839913935/igapyondiary-22)
-* [いがぴょん検索](https://www.google.co.jp/#pws=0&q=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
+* [Search 'いがぴょん' in google](https://www.google.co.jp/#pws=0&q=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
 * [いがぴょん検索サイト内](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
 * [いがぴょんTwitter](https://twitter.com/search?q=%23%E4%BC%8A%E8%B3%80%E6%95%8F%E6%A8%B9)
 * [Share on Twitter](https://twitter.com/intent/tweet?hashtags=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93&text=%E3%83%86%E3%82%B9%E3%83%88&url=https%3A%2F%2Figapyon.github.io%2Fdiary%2Ftest%2Fdata%2Fhatena%2Fig161226.html)

--- a/test/data/hatena/ig161226.html.md
+++ b/test/data/hatena/ig161226.html.md
@@ -31,7 +31,7 @@ test data.
 * [Search 'いがぴょん' in google](https://www.google.co.jp/#pws=0&q=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
 * [いがぴょん検索サイト内](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
 * [いがぴょんTwitter](https://twitter.com/search?q=%23%E4%BC%8A%E8%B3%80%E6%95%8F%E6%A8%B9)
-* [Share on Twitter](https://twitter.com/intent/tweet?hashtags=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93&text=%E3%83%86%E3%82%B9%E3%83%88&url=https%3A%2F%2Figapyon.github.io%2Fdiary%2Ftest%2Fdata%2Fhatena%2Fig161226.html)
+* [Share on Twitter](https://twitter.com/intent/tweet?hashtags=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93&text=%5Bmaven%5D+Title+for+test&url=https%3A%2F%2Figapyon.github.io%2Fdiary%2Ftest%2Fdata%2Fhatena%2Fig161226.html)
 * [地図で表示](https://openstreetmap.jp/map#zoom=17&lat=35.6722478&lon=139.7214164&layers=00BFF)
 
 #### [Publickey](http://www.publickey1.jp/)

--- a/test/data/hatena/ig161226.html.src.md
+++ b/test/data/hatena/ig161226.html.src.md
@@ -25,3 +25,5 @@ http://d.hatena.ne.jp/igapyon/20161222
 <@rssfeed url="http://www.publickey1.jp/atom.xml" maxcount="0" />
 
 <@localrss />
+
+* <@lastmodified date="2017-01-22" />

--- a/test/data/hatena/ig161226.html.src.md
+++ b/test/data/hatena/ig161226.html.src.md
@@ -19,7 +19,7 @@ http://d.hatena.ne.jp/igapyon/20161222
 * <@linksearch word="いがぴょん" />
 * <@linksearch title="いがぴょん検索サイト内" word="いがぴょん" site="https://igapyon.github.io/diary/" />
 * <@linksearch title="いがぴょんTwitter" word="伊賀敏樹" engine="twitter" />
-* <@linkshare word="テスト" tags="いがぴょん" />
+* <@linkshare word="${current.title}" tags="いがぴょん" />
 * <@linkmap word="mapテスト" lat="35.6722478" lon="139.7214164" />
 
 <@rssfeed url="http://www.publickey1.jp/atom.xml" maxcount="0" />

--- a/test/data/hatena/ig161226.html.src.md
+++ b/test/data/hatena/ig161226.html.src.md
@@ -16,7 +16,7 @@ http://d.hatena.ne.jp/igapyon/20161222
 <@localyearlist />
 
 * <@linkamazon title="JDBC本" dp="4839913935" />
-* <@linksearch title="いがぴょん検索" word="いがぴょん" />
+* <@linksearch word="いがぴょん" />
 * <@linksearch title="いがぴょん検索サイト内" word="いがぴょん" site="https://igapyon.github.io/diary/" />
 * <@linksearch title="いがぴょんTwitter" word="伊賀敏樹" engine="twitter" />
 * <@linkshare word="テスト" tags="いがぴょん" />

--- a/test/data/hatena/ig161226.src.hatenadiary
+++ b/test/data/hatena/ig161226.src.hatenadiary
@@ -20,3 +20,5 @@ http://d.hatena.ne.jp/igapyon/20161222
 <@rssfeed url="http://www.publickey1.jp/atom.xml" maxcount="0" />
 
 <@localrss />
+
+* <@lastmodified date="2017-01-22" />

--- a/test/data/hatena/ig161226.src.hatenadiary
+++ b/test/data/hatena/ig161226.src.hatenadiary
@@ -14,7 +14,7 @@ http://d.hatena.ne.jp/igapyon/20161222
 * <@linksearch word="いがぴょん" />
 * <@linksearch title="いがぴょん検索サイト内" word="いがぴょん" site="https://igapyon.github.io/diary/" />
 * <@linksearch title="いがぴょんTwitter" word="伊賀敏樹" engine="twitter" />
-* <@linkshare word="テスト" tags="いがぴょん" />
+* <@linkshare word="${current.title}" tags="いがぴょん" />
 * <@linkmap word="mapテスト" lat="35.6722478" lon="139.7214164" />
 
 <@rssfeed url="http://www.publickey1.jp/atom.xml" maxcount="0" />

--- a/test/data/hatena/ig161226.src.hatenadiary
+++ b/test/data/hatena/ig161226.src.hatenadiary
@@ -11,7 +11,7 @@ http://d.hatena.ne.jp/igapyon/20161222
 <@localyearlist />
 
 * <@linkamazon title="JDBC本" dp="4839913935" />
-* <@linksearch title="いがぴょん検索" word="いがぴょん" />
+* <@linksearch word="いがぴょん" />
 * <@linksearch title="いがぴょん検索サイト内" word="いがぴょん" site="https://igapyon.github.io/diary/" />
 * <@linksearch title="いがぴょんTwitter" word="伊賀敏樹" engine="twitter" />
 * <@linkshare word="テスト" tags="いがぴょん" />


### PR DESCRIPTION
v1.2.6

* md2html のファイル名変換処理が、igapyonv3 のファイル名ルールに合致していないバグがあった。これを訂正しました。
* mdsrc2md で include 時に親オブジェクトの変数を引き継げるように改良。
* lastmodified ディレクティブを追加した。ただし、現状は基本的に名前予約程度の位置付け。
* FreeMarker の変数に current というものを追加。igapyonv3 独自の変数に該当する。