### PR TITLE
Fix search/map links and bump version to 2.0.20260104.3

### DIFF
--- a/lib/commons-cli/CONTRIBUTING.html
+++ b/lib/commons-cli/CONTRIBUTING.html
@@ -8,7 +8,7 @@ the open source community. Before you dig right into the code there are a few gu
 follow so that we can have a chance of keeping on top of things.
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Contributing to Apache Commons CLI</title>
 <meta property="og:title" content="Contributing to Apache Commons CLI">
 <meta name="twitter:title" content="Contributing to Apache Commons CLI">

--- a/lib/commons-cli/README.html
+++ b/lib/commons-cli/README.html
@@ -6,7 +6,7 @@
 <meta name="description" content="Apache Commons CLI provides a simple API for presenting, processing and validating a command line interface.
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Apache Commons CLI</title>
 <meta property="og:title" content="Apache Commons CLI">
 <meta name="twitter:title" content="Apache Commons CLI">

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>jp.igapyon.diary</groupId>
 	<artifactId>igapyonv3</artifactId>
-	<version>2.0.20260104.2</version> <!-- SNAPSHOT は maven repos リリース時に追加など工夫して -->
+	<version>2.0.20260104.3</version> <!-- SNAPSHOT は maven repos リリース時に追加など工夫して -->
 	<packaging>jar</packaging>
 
 	<name>igapyonv3</name>

--- a/src/main/java/jp/igapyon/diary/igapyonv3/md2html/IgapyonMd2HtmlConstants.java
+++ b/src/main/java/jp/igapyon/diary/igapyonv3/md2html/IgapyonMd2HtmlConstants.java
@@ -40,5 +40,5 @@ package jp.igapyon.diary.igapyonv3.md2html;
 public class IgapyonMd2HtmlConstants {
 	public static final String PROGRAM_DISPLAY_NAME = "Igapyon Diary System v3 (igapyonv3)";
 
-	public static final String VERSION = "2.0.20260104.2";
+	public static final String VERSION = "2.0.20260104.3";
 }

--- a/src/main/java/jp/igapyon/diary/igapyonv3/mdconv/freemarker/directive/LinkMapDirectiveModel.java
+++ b/src/main/java/jp/igapyon/diary/igapyonv3/mdconv/freemarker/directive/LinkMapDirectiveModel.java
@@ -93,8 +93,8 @@ public class LinkMapDirectiveModel implements TemplateDirectiveModel {
 	 * @return formatted string.
 	 */
 	public String getOutputString(final String titleString, final String latString, final String lonString) {
-		String qString = "https://openstreetmap.jp/map#zoom=17&lat=" + latString + "&lon=" + lonString
-				+ "&layers=00BFF";
+		String qString = "https://www.openstreetmap.org/?mlat=" + latString + "&mlon=" + lonString + "#map=17/"
+				+ latString + "/" + lonString;
 		return ("[" + titleString + "](" + qString + ")");
 	}
 }

--- a/src/main/java/jp/igapyon/diary/igapyonv3/mdconv/freemarker/directive/LinkSearchDirectiveModel.java
+++ b/src/main/java/jp/igapyon/diary/igapyonv3/mdconv/freemarker/directive/LinkSearchDirectiveModel.java
@@ -99,8 +99,8 @@ public class LinkSearchDirectiveModel implements TemplateDirectiveModel {
 
 		final URLCodec codec = new URLCodec();
 		try {
-			String qString = "https://www.google.co.jp/#pws=0&q="
-					+ (siteString == null ? "" : "site:" + codec.encode(siteString) + "+") + codec.encode(wordString);
+			final String queryString = (siteString == null ? "" : "site:" + siteString + " ") + wordString;
+			String qString = "https://www.google.com/search?q=" + codec.encode(queryString);
 			if ("twitter".equals(engineString)) {
 				// twitter はサイト内検索はサポートしません。
 				// TODO site指定の際にエラー処理が必要か検討。

--- a/test/data/hatena/ig161226.html.md
+++ b/test/data/hatena/ig161226.html.md
@@ -38,11 +38,11 @@ http://d.hatena.ne.jp/igapyon/20161222
 * [target](https://igapyon.github.io/diary/hatena/ig161226.html)
 * [source](https://github.com/igapyon/diary/blob/gh-pages/hatena/ig161226.src.md)
 * [JDBC本](https://www.amazon.co.jp/exec/obidos/ASIN/4839913935/igapyondiary-22)
-* [Search 'いがぴょん' in google](https://www.google.co.jp/#pws=0&q=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
-* [いがぴょん検索サイト内](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
+* [Search 'いがぴょん' in google](https://www.google.com/search?q=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
+* [いがぴょん検索サイト内](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
 * [いがぴょんTwitter](https://twitter.com/search?q=%23%E4%BC%8A%E8%B3%80%E6%95%8F%E6%A8%B9)
 * [Share on Twitter](https://twitter.com/intent/tweet?hashtags=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93&text=%5Bmaven%5D+Title+for+test&url=https%3A%2F%2Figapyon.github.io%2Fdiary%2Fhatena%2Fig161226.html)
-* [地図で表示](https://openstreetmap.jp/map#zoom=17&lat=35.6722478&lon=139.7214164&layers=00BFF)
+* [地図で表示](https://www.openstreetmap.org/?mlat=35.6722478&mlon=139.7214164#map=17/35.6722478/139.7214164)
 
 * next
 

--- a/test/data/hatena/ig161226.md
+++ b/test/data/hatena/ig161226.md
@@ -38,11 +38,11 @@ http://d.hatena.ne.jp/igapyon/20161222
 * [target](https://igapyon.github.io/diary/hatena/ig161226.html)
 * [source](https://github.com/igapyon/diary/blob/gh-pages/hatena/ig161226.src.md)
 * [JDBC本](https://www.amazon.co.jp/exec/obidos/ASIN/4839913935/igapyondiary-22)
-* [Search 'いがぴょん' in google](https://www.google.co.jp/#pws=0&q=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
-* [いがぴょん検索サイト内](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
+* [Search 'いがぴょん' in google](https://www.google.com/search?q=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
+* [いがぴょん検索サイト内](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93)
 * [いがぴょんTwitter](https://twitter.com/search?q=%23%E4%BC%8A%E8%B3%80%E6%95%8F%E6%A8%B9)
 * [Share on Twitter](https://twitter.com/intent/tweet?hashtags=%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93&text=%5Bmaven%5D+Title+for+test&url=https%3A%2F%2Figapyon.github.io%2Fdiary%2Fhatena%2Fig161226.html)
-* [地図で表示](https://openstreetmap.jp/map#zoom=17&lat=35.6722478&lon=139.7214164&layers=00BFF)
+* [地図で表示](https://www.openstreetmap.org/?mlat=35.6722478&mlon=139.7214164#map=17/35.6722478/139.7214164)
 
 * next
 

--- a/test/data/keyword/%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06.html.md
+++ b/test/data/keyword/%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06.html.md
@@ -10,16 +10,16 @@
 
 ### URL
 
-* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.co.jp/#pws=0&q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 
 ### 特徴
 
-* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.co.jp/#pws=0&q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 
 ### 検索
 
-* [Search '![いがぴょん画像(小) 2003/06' in google in-site](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
-* [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.co.jp/#pws=0&q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* [Search '![いがぴょん画像(小) 2003/06' in google in-site](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 * [Search '![いがぴょん画像(小) 2003/06' in twitter](https://twitter.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 
 ### 日記

--- a/test/data/keyword/%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06.md
+++ b/test/data/keyword/%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06.md
@@ -10,16 +10,16 @@
 
 ### URL
 
-* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.co.jp/#pws=0&q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 
 ### 特徴
 
-* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.co.jp/#pws=0&q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* TBD [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 
 ### 検索
 
-* [Search '![いがぴょん画像(小) 2003/06' in google in-site](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
-* [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.co.jp/#pws=0&q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* [Search '![いがぴょん画像(小) 2003/06' in google in-site](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
+* [Search '![いがぴょん画像(小) 2003/06' in google](https://www.google.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 * [Search '![いがぴょん画像(小) 2003/06' in twitter](https://twitter.com/search?q=%21%5B%E3%81%84%E3%81%8C%E3%81%B4%E3%82%87%E3%82%93%E7%94%BB%E5%83%8F%28%E5%B0%8F%29+2003%2F06)
 
 ### 日記

--- a/test/data/keyword/maven.html.md
+++ b/test/data/keyword/maven.html.md
@@ -10,16 +10,16 @@ maven
 
 ### URL
 
-* TBD [Search 'maven' in google](https://www.google.co.jp/#pws=0&q=maven)
+* TBD [Search 'maven' in google](https://www.google.com/search?q=maven)
 
 ### 特徴
 
-* TBD [Search 'maven' in google](https://www.google.co.jp/#pws=0&q=maven)
+* TBD [Search 'maven' in google](https://www.google.com/search?q=maven)
 
 ### 検索
 
-* [Search 'maven' in google in-site](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+maven)
-* [Search 'maven' in google](https://www.google.co.jp/#pws=0&q=maven)
+* [Search 'maven' in google in-site](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+maven)
+* [Search 'maven' in google](https://www.google.com/search?q=maven)
 * [Search 'maven' in twitter](https://twitter.com/search?q=%23maven)
 
 ### 日記

--- a/test/data/keyword/maven.md
+++ b/test/data/keyword/maven.md
@@ -10,16 +10,16 @@ maven
 
 ### URL
 
-* TBD [Search 'maven' in google](https://www.google.co.jp/#pws=0&q=maven)
+* TBD [Search 'maven' in google](https://www.google.com/search?q=maven)
 
 ### 特徴
 
-* TBD [Search 'maven' in google](https://www.google.co.jp/#pws=0&q=maven)
+* TBD [Search 'maven' in google](https://www.google.com/search?q=maven)
 
 ### 検索
 
-* [Search 'maven' in google in-site](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+maven)
-* [Search 'maven' in google](https://www.google.co.jp/#pws=0&q=maven)
+* [Search 'maven' in google in-site](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+maven)
+* [Search 'maven' in google](https://www.google.com/search?q=maven)
 * [Search 'maven' in twitter](https://twitter.com/search?q=%23maven)
 
 ### 日記

--- a/test/data/keyword/test.html.md
+++ b/test/data/keyword/test.html.md
@@ -10,16 +10,16 @@ Test
 
 ### URL
 
-* TBD [Search 'Test' in google](https://www.google.co.jp/#pws=0&q=Test)
+* TBD [Search 'Test' in google](https://www.google.com/search?q=Test)
 
 ### 特徴
 
-* TBD [Search 'Test' in google](https://www.google.co.jp/#pws=0&q=Test)
+* TBD [Search 'Test' in google](https://www.google.com/search?q=Test)
 
 ### 検索
 
-* [Search 'Test' in google in-site](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+Test)
-* [Search 'Test' in google](https://www.google.co.jp/#pws=0&q=Test)
+* [Search 'Test' in google in-site](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+Test)
+* [Search 'Test' in google](https://www.google.com/search?q=Test)
 * [Search 'Test' in twitter](https://twitter.com/search?q=%23Test)
 
 ### 日記

--- a/test/data/keyword/test.md
+++ b/test/data/keyword/test.md
@@ -10,16 +10,16 @@ Test
 
 ### URL
 
-* TBD [Search 'Test' in google](https://www.google.co.jp/#pws=0&q=Test)
+* TBD [Search 'Test' in google](https://www.google.com/search?q=Test)
 
 ### 特徴
 
-* TBD [Search 'Test' in google](https://www.google.co.jp/#pws=0&q=Test)
+* TBD [Search 'Test' in google](https://www.google.com/search?q=Test)
 
 ### 検索
 
-* [Search 'Test' in google in-site](https://www.google.co.jp/#pws=0&q=site:https%3A%2F%2Figapyon.github.io%2Fdiary%2F+Test)
-* [Search 'Test' in google](https://www.google.co.jp/#pws=0&q=Test)
+* [Search 'Test' in google in-site](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Figapyon.github.io%2Fdiary%2F+Test)
+* [Search 'Test' in google](https://www.google.com/search?q=Test)
 * [Search 'Test' in twitter](https://twitter.com/search?q=%23Test)
 
 ### 日記

--- a/test/data/output/diary/2015/ig150630.html
+++ b/test/data/output/diary/2015/ig150630.html
@@ -6,7 +6,7 @@
 <meta name="description" content="いがぴょんの日記ウェブページ v3 について、Markdown 記法のものを Bootstrap 的な HTML に変換することを考えています。と、ここに書いたものが description になるとともにジャンボにもなる。
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>いがぴょん画像(小) 2003/06 2015/06/30 日記: Markdown 記法を Bootstrap 的な HTML に変換</title>
 <meta property="og:title" content="いがぴょん画像(小) 2003/06 2015/06/30 日記: Markdown 記法を Bootstrap 的な HTML に変換">
 <meta name="twitter:title" content="いがぴょん画像(小) 2003/06 2015/06/30 日記: Markdown 記法を Bootstrap 的な HTML に変換">

--- a/test/data/output/idea/idea001.html
+++ b/test/data/output/idea/idea001.html
@@ -6,7 +6,7 @@
 <meta name="description" content="I thinking about Markdown to Java. Here will be file comment header.
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea</title>
 <meta property="og:title" content="Just an idea">
 <meta name="twitter:title" content="Just an idea">

--- a/test/data/output/idea/idea002.html
+++ b/test/data/output/idea/idea002.html
@@ -6,7 +6,7 @@
 <meta name="description" content="Navi sample test.
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea for Navi</title>
 <meta property="og:title" content="Just an idea for Navi">
 <meta name="twitter:title" content="Just an idea for Navi">

--- a/test/data/output/idea/idea003.html
+++ b/test/data/output/idea/idea003.html
@@ -6,7 +6,7 @@
 <meta name="description" content="Navi sample test.
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea for Badge</title>
 <meta property="og:title" content="Just an idea for Badge">
 <meta name="twitter:title" content="Just an idea for Badge">

--- a/test/data/output/idea/idea004.html
+++ b/test/data/output/idea/idea004.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea</title>
 <meta property="og:title" content="Just an idea">
 <meta name="twitter:title" content="Just an idea">

--- a/test/data/output/idea/idea005.html
+++ b/test/data/output/idea/idea005.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea</title>
 <meta property="og:title" content="Just an idea">
 <meta name="twitter:title" content="Just an idea">

--- a/test/data/output/idea/idea006.html
+++ b/test/data/output/idea/idea006.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea</title>
 <meta property="og:title" content="Just an idea">
 <meta name="twitter:title" content="Just an idea">

--- a/test/data/output/idea/idea007.html
+++ b/test/data/output/idea/idea007.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea</title>
 <meta property="og:title" content="Just an idea">
 <meta name="twitter:title" content="Just an idea">

--- a/test/data/output/idea/idea008.html
+++ b/test/data/output/idea/idea008.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea</title>
 <meta property="og:title" content="Just an idea">
 <meta name="twitter:title" content="Just an idea">

--- a/test/data/output/idea/idea009.html
+++ b/test/data/output/idea/idea009.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>Just an idea</title>
 <meta property="og:title" content="Just an idea">
 <meta name="twitter:title" content="Just an idea">

--- a/test/data/output/test001.html
+++ b/test/data/output/test001.html
@@ -6,7 +6,7 @@
 <meta name="description" content="ここに description を書く方向性にて...。h1 は冒頭のみ想定。h1 処理が待たれる。ここには画像も入れることが可能であってほしい。
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>トップレベルヘッダー</title>
 <meta property="og:title" content="トップレベルヘッダー">
 <meta name="twitter:title" content="トップレベルヘッダー">

--- a/test/data/output/test002.html
+++ b/test/data/output/test002.html
@@ -7,7 +7,7 @@
 次の # からはじまる行、および 行に加えて === または --- による行が始まるところまでを、別のファイルとしてみなして h1 ブロックを作る。
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>大きなタイトル</title>
 <meta property="og:title" content="大きなタイトル">
 <meta name="twitter:title" content="大きなタイトル">

--- a/test/data/output/test003.html
+++ b/test/data/output/test003.html
@@ -7,7 +7,7 @@
 次の # からはじまる行、および 行に加えて === または --- による行が始まるところまでを、別のファイルとしてみなして h1 ブロックを作る。
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>大きなタイトル</title>
 <meta property="og:title" content="大きなタイトル">
 <meta name="twitter:title" content="大きなタイトル">

--- a/test/data/output/test011.html
+++ b/test/data/output/test011.html
@@ -6,7 +6,7 @@
 <meta name="description" content="エスケープ文字のテスト。&<>
 ">
 <meta name="author" content="Toshiki Iga">
-<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.2">
+<meta name="generator" content="Igapyon Diary System v3 (igapyonv3) ver2.0.20260104.3">
 <title>エスケープ文字。&<></title>
 <meta property="og:title" content="エスケープ文字。&<>">
 <meta name="twitter:title" content="エスケープ文字。&<>">


### PR DESCRIPTION
Title: Fix search/map links and bump version to 2.0.20260104.3

## Summary
- linksearch の Google 検索URLを現行形式に更新し、site 検索のクエリ生成を整理
- linkmap の OpenStreetMap リンクを標準URL形式に更新
- 生成HTMLのバージョン表記を 2.0.20260104.3 に更新

## Changes
- LinkSearchDirectiveModel の検索URL生成を `google.com/search` 形式に変更
- LinkMapDirectiveModel の地図URLを `openstreetmap.org` 形式に変更
- バージョン更新に伴うテスト出力/固定HTMLの更新

Closes #55
Closes #56
Closes #57
Closes #58
